### PR TITLE
Check input before trying to normalize.

### DIFF
--- a/normalization/src/main/java/zemberek/normalization/TurkishSentenceNormalizer.java
+++ b/normalization/src/main/java/zemberek/normalization/TurkishSentenceNormalizer.java
@@ -152,6 +152,10 @@ public class TurkishSentenceNormalizer {
 
   public String normalize(String sentence) {
 
+    if(sentence.matches("^\\P{L}*$")) {
+      return sentence;
+    }
+
     String processed = preProcess(sentence);
 
     List<Token> tokens = TurkishTokenizer.DEFAULT.tokenize(processed);


### PR DESCRIPTION
Description:
TurkishSentenceNormalizer.normalize() throws if the string parameter is empty or contains only whitespace characters.

Exception Stack Trace:
````
Tem 03, 2020 2:33:45 ╓╓ io.grpc.internal.SerializingExecutor run
SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@57d955bb
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
        at java.base/java.util.Objects.checkIndex(Objects.java:373)
        at java.base/java.util.ArrayList.get(ArrayList.java:426)
        at zemberek.normalization.TurkishSentenceNormalizer.combineNecessaryWords(TurkishSentenceNormalizer.java:569)
        at zemberek.normalization.TurkishSentenceNormalizer.preProcess(TurkishSentenceNormalizer.java:419)
        at zemberek.normalization.TurkishSentenceNormalizer.normalize(TurkishSentenceNormalizer.java:155)
        at zemberek.grpc.server.NormalizationServiceImpl.normalize(NormalizationServiceImpl.java:36)
        at zemberek.proto.NormalizationServiceGrpc$MethodHandlers.invoke(NormalizationServiceGrpc.java:209)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:331)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:808)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
        at java.base/java.lang.Thread.run(Thread.java:832)
````